### PR TITLE
Fix pivotEof: pivot_key dangling pointer after free.

### DIFF
--- a/pivot_vtab.c
+++ b/pivot_vtab.c
@@ -565,6 +565,7 @@ static int pivotEof(sqlite3_vtab_cursor *pCur){
       for( i=0; i<tab->nRow_cols; i++ )
         sqlite3_value_free(cur->pivot_key[i]);
       sqlite3_free(cur->pivot_key);
+      cur->pivot_key = 0;
     }
     sqlite3_finalize(cur->stmt);
     cur->stmt = 0;


### PR DESCRIPTION
I think this is the cause of all three current issues.

Tested with sqlite3 v3.42.0 on Windows WSL2. The demo script in README.md aborted with a segmentation fault. After the fix, it runs fine.